### PR TITLE
[dx] Introduce GitHub action to run ESLint, Prettier, and TypeScript compiler

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
       # Install packages #
       ################################
       - name: Install packages
-        run: npm ci
+        run: yarn install --frozen-lockfile
       ################################
       # Check ESLint on codebase #
       ################################

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,56 @@
+---
+name: Lint
+
+#############################
+# Start the job on push #
+#############################
+on:
+  push:
+    branches-ignore: [main]
+  pull_request:
+    branches: [main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Run ESLint, Prettier, and TypeScript compiler
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper
+          # list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Install packages #
+      ################################
+      - name: Install packages
+        run: npm ci
+      ################################
+      # Check ESLint on codebase #
+      ################################
+      - name: Run ESLint
+        run: npx eslint .
+      ################################
+      # Check Prettier on codebase #
+      ################################
+      - name: Run Prettier
+        run: npx prettier --check .
+      ################################
+      # Check for TypeScript errors #
+      ################################
+      - name: Run TypeScript compiler (tsc)
+        run: npx tsc --noEmit


### PR DESCRIPTION
## Documentation
Introduced a GitHub Action to:
- Run ESLint
- Run Prettier check across the whole repo
- Run the TypeScript compiler to check for type errors

## How to Review
[Here's an example output](https://github.com/calblueprint/chinese-newcomers/actions/runs/4338460158/jobs/7575174888) from the Action running on a commit in this PR.

## Related PRs
Similar to changes made in V4V: https://github.com/calblueprint/vouchers4veggies/pull/50, https://github.com/calblueprint/vouchers4veggies/blob/main/.github/workflows/lint.yml

## Screenshots
Example output -- since there are still linter errors in the repo, it will fail until all linter, prettier, and TS errors are fixed.
<img width="1268" alt="image" src="https://user-images.githubusercontent.com/21160510/222991616-8f3849aa-581c-4f82-af24-eda6dce05037.png">

CC: @surajr10 @alliu879 